### PR TITLE
set.status -> self.status

### DIFF
--- a/heatmiserV3/connection.py
+++ b/heatmiserV3/connection.py
@@ -39,7 +39,7 @@ class HeatmiserUH1(object):
             return False
 
     def reopen(self):
-        if not set.status:
+        if not self.status:
             self._serport.open()
             self.status = True
             return self.status


### PR DESCRIPTION
This typo seems to cause crashes if I use the newest version of this library with home assistant.

Hopefully we can get the HA manifest.json updated, as with the version of heatmiserv3 that home assistant ships with, it's reading my current_temperature wrong, but the newest version and this patch has things working for me.