### PR TITLE
Fix heatmiser config loading

### DIFF
--- a/heatmiserv3/heatmiser.py
+++ b/heatmiserv3/heatmiser.py
@@ -100,7 +100,8 @@ class HeatmiserThermostat(object):
         self.address = address
         self.model = model
         try:
-            self.config = yaml.safe_load(config_yml)[model]
+            with open(config_yml) as config_file:
+                self.config = yaml.safe_load(config_file)[model]
         except yaml.YAMLError as exc:
             logging.info("The YAML file is invalid: %s", exc)
         self.conn = uh1.registerThermostat(self)


### PR DESCRIPTION
Seems like the most recent patches changed this from a file handle to a file path, which causes the following crash

```
Traceback (most recent call last):
  File "/home/azelphur/tmp/heatmiser2/env/get_temperature.py", line 21, in <module>
    thermo1 = heatmiser.HeatmiserThermostat(7, "prt", HeatmiserUH1)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/heatmiserv3/heatmiser.py", line 104, in __init__
    self.config = yaml.safe_load(config_yml)[model]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/yaml/__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/yaml/__init__.py", line 79, in load
    loader = Loader(stream)
             ^^^^^^^^^^^^^^
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/yaml/loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/yaml/reader.py", line 124, in determine_encoding
    self.update_raw()
  File "/home/azelphur/tmp/heatmiser2/env/lib/python3.11/site-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)
           ^^^^^^^^^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'read'
```

This patch fixes it :)