### PR TITLE
Add support for get_frost_protection

### DIFF
--- a/heatmiserv3/heatmiser.py
+++ b/heatmiserv3/heatmiser.py
@@ -366,8 +366,13 @@ class HeatmiserThermostat(object):
         modes = {0: "5/2 mode", 1: "7 day mode"}
         return modes[mode]
 
-    def get_frost_protection(self):
-        pass
+    def get_frost_protection(self) -> bool:
+        """
+        Return whether frost protection mode is enabled.
+        This is represented by the snowflake icon and is
+        the same as on/off
+        """
+        return bool(self._hm_read_address()[23]["value"])
 
     def get_floor_temp(self):
         return (


### PR DESCRIPTION
Hi :)

I noticed that, in home assistant, setting the heating mode using the heatmiser integration doesn't work. It throws NotImplementedError, also, the thermostats show as heating when the temperature is lower than the target, and off when the temperature is higher than the target. The reason for this is that HVAC mode has been used where I believe HVAC action should have been used, [relevant docs](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action)

The heatmiser thermostats support on, or frost protect. There is no completely off, however the manual states "OFF Key - Single press to enable/disable frost protection or press and hold to turn off display", so you press off to toggle frost protect mode, in my opinion, off and frost protect are the same. But of course, if you disagree, we can find another way.

So this patch is part one of fixing this. The home assistant integration needs to be able to know whether the thermostat is on or off (frost protect). This is tested and works on my system, and I have the home assistant side working locally too. But of course, before I can commit this to home assistant, we'd need this merged and a version bump.

Hopefully that all makes sense. Thanks! :)