### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Build & Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/andylockran/heatmiserV3/security/code-scanning/3](https://github.com/andylockran/heatmiserV3/security/code-scanning/3)

To fix the problem, you should add a `permissions:` block to restrict the permissions granted to the `GITHUB_TOKEN`. The best way is to add this at the workflow root level (above `jobs:`) so it applies to all jobs in the workflow unless jobs need specific exceptions (which this workflow does not). The minimal recommended setting is `contents: read`, which allows reading repository contents but restricts any write actions. No additional imports, methods, or definitions are needed, as this is a YAML declarative change. You should edit the `.github/workflows/python-package.yml` file to insert the following block after the workflow name:

```yaml
permissions:
  contents: read
```

This should be inserted after line 4.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
